### PR TITLE
By specifying a prefix of the field's name on each Autocomplete form,…

### DIFF
--- a/djaa_list_filter/admin.py
+++ b/djaa_list_filter/admin.py
@@ -66,7 +66,7 @@ class AjaxAutocompleteListFilter(admin.RelatedFieldListFilter):
         initial_values = dict(querystring_value=request.GET.urlencode())
         if autocomplete_field_initial_value:
             initial_values.update(autocomplete_field=autocomplete_field_initial_value)
-        self.autocomplete_form = AutocompleteForm(initial=initial_values)
+        self.autocomplete_form = AutocompleteForm(initial=initial_values, prefix=field.name)
 
     def get_queryset_for_field(self, model, name):
         """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(CURRENT_WORKING_DIRECTORY, 'README.md')) as fp:
 
 setup(
     name='django-admin-autocomplete-list-filter',
-    version='0.1.4',
+    version='0.1.5',
     description='Ajax autocomplete list filter for Django admin',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
… multiple autocomplete filters can be put on the page. Without this, all fields are named/IDed autocomplete_field and there's a collision.