### PR TITLE
Update autocomplete select init to be compatible with django 3.2

### DIFF
--- a/djaa_list_filter/admin.py
+++ b/djaa_list_filter/admin.py
@@ -28,7 +28,7 @@ class AjaxAutocompleteSelectWidget(AutocompleteSelect):
         self.model = kwargs.pop('model')
         self.field_name = kwargs.pop('field_name')
         kwargs.update(admin_site=self.model_admin.admin_site)
-        kwargs.update(rel=getattr(self.model, self.field_name).field.remote_field)
+        kwargs.update(field=getattr(self.model, self.field_name).field)
         super().__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(CURRENT_WORKING_DIRECTORY, 'README.md')) as fp:
 
 setup(
     name='django-admin-autocomplete-list-filter',
-    version='0.1.5.2',
+    version='0.1.5.3',
     description='Ajax autocomplete list filter for Django admin',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR never went through but contains the fix to our admin autocomplete to allow it to be compatible with django 3.2
https://github.com/demiroren-teknoloji/django-admin-autocomplete-list-filter/pull/6